### PR TITLE
Add functionality #12

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ AWS gitlab:
     AWS_REGION: us-east-1
   stage: deployment test
   script:
-    - molecule test -s default
+    - molecule test -s cloud-aws-direct
   tags:
     - aws
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,9 +27,18 @@ Docker gitlab:
   script:
     - molecule test -s default
   tags:
-    - docker
+    - aws
 
 AWS gitlab:
+  variables:
+    AWS_REGION: us-east-1
+  stage: deployment test
+  script:
+    - molecule test -s default
+  tags:
+    - aws
+
+.AWS gitlab:
   variables:
     EPC_REGION: AWS-EUCENTRAL
   stage: deployment test
@@ -38,7 +47,7 @@ AWS gitlab:
   tags:
     - delegated
 
-EPC gitlab:
+.EPC gitlab:
   variables:
     EPC_REGION: EPAM-BY2
   stage: deployment test

--- a/README.md
+++ b/README.md
@@ -136,38 +136,40 @@ Requirements
      default: `False`
 
 # gitlab group creation/configuration
-  - `gitlab_project_group_create` - to create gitlab group; correct gitlab_admin_token should be set if gitlab not installed by this role   
+  - `gitlab_project_group_create` - to create gitlab group; correct gitlab_admin_token should be set if gitlab not installed by this role
      default: `False`
-  - `gitlab_project_group` - group name   
+  - `gitlab_project_group` - group name
      default: `test_group`
-  - `gitlab_project_group_id` - group id; should be set if group creation is False   
+  - `gitlab_project_group_id` - group id; should be set if group creation is False
      default: `1`
 # gitlab project creation/configuration
-  - `gitlab_project_create` - to create gitlab project; correct gitlab_admin_token should be set if gitlab not installed by this role   
+  - `gitlab_project_create` - to create gitlab project; correct gitlab_admin_token should be set if gitlab not installed by this role
      default: `False`
-  - `gitlab_project_name` - project name   
+  - `gitlab_project_name` - project name
      default: `test_project`
-  - `gitlab_project_id` - project id; should be set if project creation is False   
+  - `gitlab_project_id` - project id; should be set if project creation is False
      default: `1`
 # master user creation/configuration
-  - `gitlab_master_create` - to create gitlab project master user; correct gitlab_admin_token should be set if gitlab not installed by this role   
+  - `gitlab_master_create` - to create gitlab project master user; correct gitlab_admin_token should be set if gitlab not installed by this role
      default: `False`
-  - `gitlab_master_name` - user name     
+  - `gitlab_master_name` - user name
      default: `integrator user`
-  - `gitlab_master_username` - username   
+  - `gitlab_master_username` - username
      default: `integrator`
-  - `gitlab_master_password` - user password   
+  - `gitlab_master_password` - user password
      default: `Admin!23`
-  - `gitlab_master_email` - user email   
+  - `gitlab_master_email` - user email
      default: `admin@example.com`
-  - `gitlab_master_token_name` - name for user private api token   
+  - `gitlab_master_token_name` - name for user private api token
      default: `Created API token`
-  - `gitlab_master_token` - user token; will be created if name not exists; does not visible for user; reset variable after creation; ***Should be set manually for versions earlier than 9.0***      
+  - `gitlab_master_token` - user token; will be created if name not exists; does not visible for user; reset variable after creation; ***Should be set manually for versions earlier than 9.0***
      default: `Token!234`
 # webhooks creation
-  - `gitlab_webhooks_create` - to create webhooks; correct gitlab_admin_token should be set if gitlab not installed by this role   
+  - `gitlab_webhooks_create` - to create webhooks; correct gitlab_admin_token should be set if gitlab not installed by this role
      default: `False`
   - `gitlab_webhooks_list` - map with webhooks parameters
+  - `gitlab_allow_local_requests` - enable the option [“Allow requests to the local network from hooks and services”](https://docs.gitlab.com/ee/security/webhooks.html) in the “Outbound requests” section
+     default: `False`
     ```
     webhook1:
       hook_url: "http://server.example.com:8080/project/ci_main_branch_test"
@@ -185,7 +187,7 @@ Requirements
       token: ""
     ```
 # labels creation
-  - `gitlab_labels_create` - to create labels; correct gitlab_admin_token should be set if gitlab not installed by this role  
+  - `gitlab_labels_create` - to create labels; correct gitlab_admin_token should be set if gitlab not installed by this role
      default: `False`
   - `gitlab_labels_list` - map with labels parameters
      ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,7 @@ gitlab_project_group: test_group
 gitlab_project_group_id: 1
 
 # gitlab webhooks
+gitlab_allow_local_requests: False
 gitlab_webhooks_create: False
 gitlab_webhooks_list:
   webhook1:

--- a/molecule/cloud-aws-delegated/playbook.yml
+++ b/molecule/cloud-aws-delegated/playbook.yml
@@ -16,3 +16,4 @@
     gitlab_master_user_create: True
     gitlab_webhooks_create: True
     gitlab_labels_create: True
+    gitlab_allow_local_requests: True

--- a/molecule/cloud-aws-direct/molecule.yml
+++ b/molecule/cloud-aws-direct/molecule.yml
@@ -42,7 +42,7 @@ provisioner:
   env:
     ANSIBLE_LIBRARY: ${ANSIBLE_LIBRARY}
 scenario:
-  name: cloud-aws-direct-12.2.1.3
+  name: cloud-aws-direct
 verifier:
   name: testinfra
   options:

--- a/molecule/cloud-aws-direct/molecule.yml
+++ b/molecule/cloud-aws-direct/molecule.yml
@@ -1,0 +1,52 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: requirements.yml
+driver:
+  name: ec2
+lint:
+  name: yamllint
+  options:
+    config-file: .yamllint
+platforms:
+  - name: test-aws-centos7-gitlab
+    image: ami-9887c6e7
+    instance_type: m5.large
+    region: us-east-1
+    vpc_subnet_id: subnet-01be2149
+    spot_price: 0.04
+    wait_timeout: 1800
+    ssh_user: centos
+    groups:
+      - rhel_family
+  - name: test-aws-ubuntu1804-gitlab
+    image: ami-0ac019f4fcb7cb7e6
+    instance_type: m5.large
+    region: us-east-1
+    vpc_subnet_id: subnet-01be2149
+    spot_price: 0.04
+    wait_timeout: 1800
+    ssh_user: ubuntu
+    groups:
+      - debian_family
+provisioner:
+  name: ansible
+  log: False
+  playbooks:
+    create: ../resources/provisioning/AWS/create.yml
+    prepare: ../resources/provisioning/AWS/prepare.yml
+    destroy: ../resources/provisioning/AWS/destroy.yml
+  lint:
+    name: ansible-lint
+  env:
+    ANSIBLE_LIBRARY: ${ANSIBLE_LIBRARY}
+scenario:
+  name: cloud-aws-direct-12.2.1.3
+verifier:
+  name: testinfra
+  options:
+    verbose: true
+  directory: ../resources/tests/
+  lint:
+    name: flake8

--- a/molecule/cloud-aws-direct/playbook.yml
+++ b/molecule/cloud-aws-direct/playbook.yml
@@ -1,0 +1,19 @@
+---
+- name: Gather AWS facts
+  hosts: all
+  tasks:
+    - ec2_metadata_facts:
+
+- name: Converge
+  hosts: all
+  roles:
+    - role: ansible-role-gitlab
+  vars:
+    host_fqdn: "{{ ansible_ec2_public_hostname }}"
+    molecule_test: True
+    gitlab_project_group_create: True
+    gitlab_project_create: True
+    gitlab_master_user_create: True
+    gitlab_webhooks_create: True
+    gitlab_labels_create: True
+    gitlab_allow_local_requests: True

--- a/molecule/cloud-epc-delegated/playbook.yml
+++ b/molecule/cloud-epc-delegated/playbook.yml
@@ -10,3 +10,4 @@
     gitlab_master_user_create: True
     gitlab_webhooks_create: True
     gitlab_labels_create: True
+    gitlab_allow_local_requests: True

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -10,3 +10,4 @@
     gitlab_master_user_create: True
     gitlab_webhooks_create: True
     gitlab_labels_create: True
+    gitlab_allow_local_requests: True

--- a/molecule/resources/provisioning/AWS/create.yml
+++ b/molecule/resources/provisioning/AWS/create.yml
@@ -1,0 +1,117 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not ((lookup('env', 'MOLECULE_DEBUG') | bool) or (molecule_yml.provisioner.log | default(false) | bool)) }}"
+  vars:
+    ssh_port: 22
+
+    security_group_name: molecule
+    security_group_description: Security group for testing Molecule
+    security_group_rules:
+      - proto: tcp
+        from_port: "{{ ssh_port }}"
+        to_port: "{{ ssh_port }}"
+        cidr_ip: '0.0.0.0/0'
+      - proto: icmp
+        from_port: 8
+        to_port: -1
+        cidr_ip: '0.0.0.0/0'
+    security_group_rules_egress:
+      - proto: -1
+        from_port: 0
+        to_port: 0
+        cidr_ip: '0.0.0.0/0'
+
+    keypair_name: molecule_key
+    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+  tasks:
+    - name: Create security group
+      ec2_group:
+        name: "{{ security_group_name }}"
+        description: "{{ security_group_name }}"
+        rules: "{{ security_group_rules }}"
+        rules_egress: "{{ security_group_rules_egress }}"
+
+    - name: Persist the keypair
+      copy:
+        dest: "{{ keypair_path }}"
+        content: "{{ lookup('env', 'SSH_PRIVATE_KEY') }}"
+        mode: 0600
+      no_log: True
+
+    - name: Test for presence of local keypair
+      stat:
+        path: "{{ keypair_path }}"
+      register: keypair_local
+
+    - name: Create molecule instance(s)
+      ec2:
+        key_name: "{{ keypair_name }}"
+        image: "{{ item.image }}"
+        instance_type: "{{ item.instance_type }}"
+        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+        group:
+          - "{{ security_group_name }}"
+          - default
+          - epam-by-ru
+        instance_tags:
+          instance: "{{ item.name }}"
+          Name: "{{ item.name }}"
+          ssh_user: "{{ item.ssh_user }}"
+        spot_price: "{{ item.spot_price }}"
+        wait: True
+        assign_public_ip: true
+        exact_count: 1
+        count_tag:
+          instance: "{{ item.name }}"
+      register: server
+      changed_when: false
+      loop: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      loop: "{{ server.results }}"
+      register: instance_create
+      until: instance_create.finished
+      delay: 5
+      retries: 300
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config dict
+      set_fact:
+        instance_conf_dict: {
+          'instance': "{{ item.instances[0].tags.instance }}",
+          'address': "{{ item.instances[0].public_ip }}",
+          'user': "{{ item.instances[0].tags.ssh_user }}",
+          'port': "{{ ssh_port }}",
+          'identity_file': "{{ keypair_path }}",
+          'instance_ids': "{{ item.instance_ids }}", }
+      loop: "{{ instance_create.results }}"
+      register: instance_config_dict
+      when: instance_create.changed | bool
+
+    - name: Convert instance config dict to a list
+      set_fact:
+        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+      when: instance_create.changed | bool
+
+    - name: Dump instance config
+      copy:
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: instance_create.changed | bool
+
+    - name: Wait for SSH
+      wait_for:
+        port: "{{ ssh_port }}"
+        host: "{{ item.address }}"
+        search_regex: SSH
+        delay: 10
+        timeout: 320
+      loop: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"

--- a/molecule/resources/provisioning/AWS/destroy.yml
+++ b/molecule/resources/provisioning/AWS/destroy.yml
@@ -1,0 +1,31 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ (not lookup('env', 'MOLECULE_DEBUG') | bool) or (molecule_yml.provisioner.log | default(False) | bool) }}"
+  tasks:
+
+    - name: Get instances list
+      ec2_instance_facts:
+        filters:
+          "tag:instance": "{{ molecule_yml.platforms | map(attribute='name') | list }}"
+      register: ec2_sets
+
+    - name: Destroy molecule instance(s)
+      ec2:
+        state: absent
+        instance_ids: "{{ ec2_sets.instances | map(attribute='instance_id') | list }}"
+        wait: True
+      register: server
+      when: ( ec2_sets.instances | map(attribute='instance_id') | list | length )
+
+    - name: Populate instance config
+      set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      copy:
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool

--- a/molecule/resources/provisioning/AWS/prepare.yml
+++ b/molecule/resources/provisioning/AWS/prepare.yml
@@ -1,0 +1,9 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Install python for Ansible
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal python-zipstream)
+      become: true
+      changed_when: false

--- a/tasks/create_webhooks.yml
+++ b/tasks/create_webhooks.yml
@@ -14,6 +14,21 @@
   set_fact:
     webhook_url_list: "{{ webhooks_list_output.json | map(attribute='url') | list }}"
 
+- name: "Enable outbound requests"
+  uri:
+    url: "{{ gitlab_external_url }}/api/{{ gitlab_api_version }}/\
+      application/settings"
+    method: "PUT"
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_admin_token }}"
+    body: "allow_local_requests_from_hooks_and_services={{ gitlab_allow_local_requests }}"
+    body_format: raw
+    validate_certs: "{{ gitlab_validate_certs }}"
+    status_code: 200
+  when:
+    - gitlab_allow_local_requests
+    - ( gitlab_version is version('10.6', '>=') or gitlab_version == "latest" )
+
 - name: "Add webhooks"
   uri:
     url: "{{ gitlab_external_url }}/api/{{ gitlab_api_version }}/projects/\

--- a/tasks/create_webhooks.yml
+++ b/tasks/create_webhooks.yml
@@ -21,7 +21,7 @@
     method: "PUT"
     headers:
       PRIVATE-TOKEN: "{{ gitlab_admin_token }}"
-    body: "allow_local_requests_from_hooks_and_services={{ gitlab_allow_local_requests }}"
+    body: "allow_local_requests_from_hooks_and_services={{ gitlab_allow_local_requests | lower }}"
     body_format: raw
     validate_certs: "{{ gitlab_validate_certs }}"
     status_code: 200


### PR DESCRIPTION
 enable the option “Allow requests to the local network from hooks and services” in the “Outbound requests” section #12 